### PR TITLE
instrument: add per-block proof target distribution logging

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -1466,6 +1466,26 @@ fn get_proof_targets(
             }
         }
 
+        // TEMP INSTRUMENTATION: log state update proof target distribution
+        {
+            let total_storage: usize = targets.storage_targets.values().map(|s| s.len()).sum();
+            let mut per_account: Vec<_> = targets.storage_targets.iter()
+                .map(|(addr, slots)| (*addr, slots.len()))
+                .collect();
+            per_account.sort_by(|a, b| b.1.cmp(&a.1));
+            let top10: Vec<String> = per_account.iter().take(10)
+                .map(|(addr, count)| format!("{:?}={}", addr, count))
+                .collect();
+            tracing::info!(
+                target: "reth::stateupdate::targets",
+                new_accounts = targets.account_targets.len(),
+                total_storage_targets = total_storage,
+                accounts_with_storage = per_account.len(),
+                top10 = %top10.join(", "),
+                "state update proof target distribution"
+            );
+        }
+
         VersionedMultiProofTargets::V2(targets)
     } else {
         let mut targets = MultiProofTargets::default();

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -751,6 +751,8 @@ fn multiproof_targets_v2_from_state(state: EvmState) -> (VersionedMultiProofTarg
 
     let mut targets = MultiProofTargetsV2::default();
     let mut storage_target_count = 0;
+    // TEMP: collect hash→address mapping for instrumentation
+    let mut addr_map: std::collections::HashMap<alloy_primitives::B256, alloy_primitives::Address> = std::collections::HashMap::new();
     for (addr, account) in state {
         // if the account was not touched, or if the account was selfdestructed, do not
         // fetch proofs for it
@@ -764,6 +766,7 @@ fn multiproof_targets_v2_from_state(state: EvmState) -> (VersionedMultiProofTarg
         }
 
         let hashed_address = keccak256(addr);
+        addr_map.insert(hashed_address, addr);
         targets.account_targets.push(hashed_address.into());
 
         let mut storage_slots = Vec::with_capacity(account.storage.len());
@@ -781,6 +784,28 @@ fn multiproof_targets_v2_from_state(state: EvmState) -> (VersionedMultiProofTarg
         if !storage_slots.is_empty() {
             targets.storage_targets.insert(hashed_address, storage_slots);
         }
+    }
+
+    // TEMP INSTRUMENTATION: log per-account storage target distribution
+    {
+        let mut per_account: Vec<_> = targets.storage_targets.iter()
+            .map(|(hashed, slots)| {
+                let orig = addr_map.get(hashed).map(|a| format!("{:?}", a)).unwrap_or_else(|| format!("{:?}", hashed));
+                (orig, slots.len())
+            })
+            .collect();
+        per_account.sort_by(|a, b| b.1.cmp(&a.1));
+        let top10: Vec<String> = per_account.iter().take(10)
+            .map(|(addr, count)| format!("{}={}", addr, count))
+            .collect();
+        tracing::info!(
+            target: "reth::prefetch::targets",
+            total_accounts = targets.account_targets.len(),
+            total_storage_targets = storage_target_count,
+            accounts_with_storage = per_account.len(),
+            top10 = %top10.join(", "),
+            "prefetch proof target distribution"
+        );
     }
 
     (VersionedMultiProofTargets::V2(targets), storage_target_count)


### PR DESCRIPTION
Temporary instrumentation to log per-account storage target counts during prefetch and state update proof generation. Used to identify XEN Crypto (138 storage slots) as the primary cause of block 24474338's 2x slowdown.

- prewarm.rs: log top-10 contracts by storage slots in multiproof_targets_v2_from_state()
- multiproof.rs: log state update proof target distribution in get_proof_targets()