### PR TITLE
feat(trie): add per-storage-proof duration and target count metrics

### DIFF
--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -979,6 +979,7 @@ where
         let mut trie_cursor_metrics = TrieCursorMetricsCache::default();
         let mut hashed_cursor_metrics = HashedCursorMetricsCache::default();
         let hashed_address = input.hashed_address();
+        let target_count = input.target_count();
         let proof_start = Instant::now();
 
         let result = match &input {
@@ -1046,6 +1047,9 @@ where
 
         #[cfg(feature = "metrics")]
         {
+            self.metrics.record_storage_proof_duration(proof_elapsed);
+            self.metrics.record_storage_proof_targets(target_count);
+
             // Accumulate per-proof metrics into the worker's cache
             let per_proof_cache = ProofTaskCursorMetricsCache {
                 account_trie_cursor: TrieCursorMetricsCache::default(),
@@ -1931,6 +1935,14 @@ impl StorageProofInput {
             Self::Legacy { hashed_address, .. } | Self::V2 { hashed_address, .. } => {
                 *hashed_address
             }
+        }
+    }
+
+    /// Returns the number of proof targets.
+    pub fn target_count(&self) -> usize {
+        match self {
+            Self::Legacy { target_slots, .. } => target_slots.len(),
+            Self::V2 { targets, .. } => targets.len(),
         }
     }
 }

--- a/crates/trie/parallel/src/proof_task_metrics.rs
+++ b/crates/trie/parallel/src/proof_task_metrics.rs
@@ -28,6 +28,10 @@ pub struct ProofTaskTrieMetrics {
     deferred_encoder_sync: Histogram,
     /// Histogram for dispatched storage proofs that fell back to sync due to missing root.
     deferred_encoder_dispatched_missing_root: Histogram,
+    /// Histogram of individual storage proof computation durations in seconds.
+    storage_proof_duration_seconds: Histogram,
+    /// Histogram of the number of targets per storage proof computation.
+    storage_proof_targets_count: Histogram,
 }
 
 impl ProofTaskTrieMetrics {
@@ -49,6 +53,16 @@ impl ProofTaskTrieMetrics {
     /// Record account worker idle time.
     pub fn record_account_worker_idle_time(&self, duration: Duration) {
         self.account_worker_idle_time_seconds.record(duration.as_secs_f64());
+    }
+
+    /// Record a single storage proof computation duration.
+    pub fn record_storage_proof_duration(&self, duration: Duration) {
+        self.storage_proof_duration_seconds.record(duration.as_secs_f64());
+    }
+
+    /// Record the number of targets in a single storage proof computation.
+    pub fn record_storage_proof_targets(&self, count: usize) {
+        self.storage_proof_targets_count.record(count as f64);
     }
 
     /// Record value encoder stats (deferred encoder variant counts).


### PR DESCRIPTION
Expose two new Prometheus histograms on the proof task workers to help identify straggler contracts during multiproof computation:

- `storage_proof_duration_seconds`: time for each individual storage proof (one observation per `process_storage_proof()` call)
- `storage_proof_targets_count`: number of storage slot targets in each proof

These complement the existing aggregate metrics and make it possible to spot outlier contracts (e.g. XEN Crypto with 138 storage slots causing ~1.4x longer proof times) without custom instrumentation.